### PR TITLE
CMake: switch to INTERFACE library with INTERFACE cxx_std_23

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,11 @@ include(FetchContent)
 # Set project include directory
 set(${PROJECT_NAME}_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include/${PROJECT_NAME})
 
-# Set C++ standard requirements
-set(CMAKE_CXX_STANDARD 20)
+# Default C++ standard for examples / tests / anything in this tree that
+# doesn't pick its own. The library's own C++23 requirement is declared
+# below as an INTERFACE compile feature on the target itself, so consumers
+# inherit it through the linked target — independently of this default.
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
@@ -40,24 +43,31 @@ set(${PROJECT_NAME}_HEADER
     ${${PROJECT_NAME}_INCLUDE_DIR}/function_registry.h
 )
 
-# Add the library
-add_library(${PROJECT_NAME} STATIC ${${PROJECT_NAME}_HEADER})
-
-# Explicitly set the linker language
-set_target_properties(${PROJECT_NAME} PROPERTIES LINKER_LANGUAGE CXX)
-
-# Add alias for easier linking
+# numsim-core is header-only: no sources, no compiled artefacts, just an
+# INTERFACE target carrying include paths + a C++23 feature requirement
+# that propagates to every consumer.
+#
+# Previously declared as STATIC with the headers listed as sources, plus
+# `target_compile_features(... PRIVATE cxx_std_20)`. Both were bugs:
+#   - STATIC with header-only "sources" produces an empty archive.
+#   - PRIVATE on a header-only target doesn't propagate, so consumers
+#     compiled with whatever standard they happened to have — and broke
+#     on `<print>` from input_parameter_controller.h.
+add_library(${PROJECT_NAME} INTERFACE)
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
-# Include directories
-target_include_directories(
-  ${PROJECT_NAME}
-  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-          $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+# Headers are reachable from the build tree and from the install tree.
+target_include_directories(${PROJECT_NAME}
+    INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-# Enable required C++ features
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
+# C++23 propagates via INTERFACE — every consumer that links
+# numsim-core::numsim-core inherits the requirement and gets compiled
+# with at least C++23. This is what makes `#include <print>` work in
+# downstream TUs (rvegen, Tessera, etc.).
+target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_23)
 
 # Build options
 option(${PROJECT_NAME}_INSTALL_LIBRARY "Enable installing of ${PROJECT_NAME} library" ON)


### PR DESCRIPTION
Closes #3.

## Summary

Fix three CMake bugs that prevent C++23 requirements from propagating to consumers and produce an empty static archive:

- `add_library(... STATIC ${HEADERS})` → `add_library(... INTERFACE)` (header-only)
- `target_compile_features(... PRIVATE cxx_std_20)` → `... INTERFACE cxx_std_23`
- Drop `set_target_properties(... LINKER_LANGUAGE CXX)` (workaround no longer needed)
- Bump default `CMAKE_CXX_STANDARD` from 20 to 23 so in-tree examples / tests use the same standard as consumers will

The existing `install(TARGETS ...)` block stays unchanged — `ARCHIVE`/`LIBRARY`/`RUNTIME DESTINATION` are silently no-ops on INTERFACE libraries, and `install(EXPORT ...)` works the same way.

See #3 for the full problem write-up.

## Why this matters

`input_parameter_controller.h` uses `std::print` / `std::println` (C++23). Today, downstream consumers must set `CMAKE_CXX_STANDARD 23` themselves to make `#include <numsim-core/input_parameter_controller.h>` compile. After this PR, `target_link_libraries(my_target PRIVATE numsim-core::numsim-core)` is enough — the C++23 requirement rides the link.

This unblocks the rvegen + Tessera install/export story without each downstream project having to redeclare numsim-core's standard.

## Test plan

- [x] `cmake -S . -B build && cmake --build build` succeeds.
- [x] `ctest` results unchanged from main: same 2 pre-existing failures (`InputParameterTest.TestInvalidType`, `input_parameter_controller_test`) caused by test code expecting `std::bad_any_cast` while runtime now wraps it in `std::invalid_argument`. Unrelated to this PR; tracked separately.
- [x] All 44 other tests pass.
- [ ] CI on this PR confirms the above on a clean checkout.

## Out of scope

- The 2 pre-existing test failures (separate PR).
- API additions on `feature/schema-gui-metadata` (`.min`/`.max`/`.units` chainable hints) — a follow-up PR; rvegen depends on those landing too before its CI can run green against `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)