### PR TITLE
Add min/max/units chainable hints on input_parameter_base

### DIFF
--- a/include/numsim-core/input_parameter_controller.h
+++ b/include/numsim-core/input_parameter_controller.h
@@ -7,6 +7,7 @@
 #include <functional>
 #include <list>
 #include <memory>
+#include <optional>
 #include <print>
 #include <string>
 #include <typeindex>
@@ -595,10 +596,59 @@ public:
    */
   inline std::string const& description() const { return m_description; }
 
+  /**
+   * @brief Sets the minimum-value hint for this parameter.
+   *
+   * Stored as double regardless of the parameter's underlying C++ type;
+   * downcasting is the consumer's responsibility. Used by GUIs (e.g. Tessera)
+   * to bound spinbox ranges; not enforced by check_parameter (use
+   * `.add<check_range>(low, high)` for runtime validation).
+   *
+   * @param v The minimum value hint.
+   * @return Reference to this object for chaining.
+   */
+  inline auto& min(double v) noexcept { m_min = v; return *this; }
+
+  /**
+   * @brief Sets the maximum-value hint for this parameter.
+   *
+   * @param v The maximum value hint.
+   * @return Reference to this object for chaining.
+   */
+  inline auto& max(double v) noexcept { m_max = v; return *this; }
+
+  /**
+   * @brief Sets the units string for this parameter (e.g. "m", "rad", "%").
+   *
+   * Used by GUIs to suffix labels/spinboxes; ignored by validation.
+   *
+   * @param u The units string.
+   * @return Reference to this object for chaining.
+   */
+  inline auto& units(std::string u) { m_units = std::move(u); return *this; }
+
+  /**
+   * @brief Returns the minimum-value hint, if set.
+   */
+  inline std::optional<double> const& min() const noexcept { return m_min; }
+
+  /**
+   * @brief Returns the maximum-value hint, if set.
+   */
+  inline std::optional<double> const& max() const noexcept { return m_max; }
+
+  /**
+   * @brief Returns the units string (empty if unset).
+   */
+  inline std::string const& units() const noexcept { return m_units; }
+
 protected:
   const KeyType m_name; ///< Name of the parameter.
   std::list<child_type> m_child; ///< Child parameters.
   std::string m_description; ///< Parameter description.
+  std::optional<double> m_min; ///< Minimum-value hint for GUIs.
+  std::optional<double> m_max; ///< Maximum-value hint for GUIs.
+  std::string m_units; ///< Units string for GUIs (e.g. "m", "rad").
 };
 
 // --- input_parameter<T> ---

--- a/tests/parameter_handler/main.cpp
+++ b/tests/parameter_handler/main.cpp
@@ -211,3 +211,63 @@ TEST_F(InputParameterTest, TestMultipleChecks_Fail) {
   // This should fail the test because the value is out of the allowed range
   EXPECT_THROW(paramController.check_parameter(handler), std::invalid_argument);
 }
+
+// ---------------------------------------------------------------------------
+// GUI-metadata hints (.min / .max / .units / .description)
+//
+// These attributes are read by GUI form-builders (e.g. Tessera) to render
+// type-aware widgets with bounded ranges, unit suffixes, and tooltips. They
+// do NOT participate in runtime validation — that's check_range's job.
+// ---------------------------------------------------------------------------
+
+TEST_F(InputParameterTest, TestMetadataDefaultsAreEmpty) {
+  input_parameter_controller<std::string, MockParameterHandler> paramController;
+  auto &param = paramController.insert<double>("plain_param");
+
+  EXPECT_FALSE(param.min().has_value());
+  EXPECT_FALSE(param.max().has_value());
+  EXPECT_TRUE(param.units().empty());
+  EXPECT_TRUE(param.description().empty());
+}
+
+TEST_F(InputParameterTest, TestMetadataSettersChain) {
+  input_parameter_controller<std::string, MockParameterHandler> paramController;
+  auto &param = paramController.insert<double>("radius");
+  param.min(0.0).max(1.0).units("m").description("particle radius");
+
+  ASSERT_TRUE(param.min().has_value());
+  EXPECT_DOUBLE_EQ(*param.min(), 0.0);
+  ASSERT_TRUE(param.max().has_value());
+  EXPECT_DOUBLE_EQ(*param.max(), 1.0);
+  EXPECT_EQ(param.units(), "m");
+  EXPECT_EQ(param.description(), "particle radius");
+}
+
+TEST_F(InputParameterTest, TestMetadataDoesNotEnforce) {
+  // Setting min/max attaches GUI hints but no runtime check. A value
+  // outside [min,max] still passes check_parameter() unless check_range
+  // is also added.
+  input_parameter_controller<std::string, MockParameterHandler> paramController;
+  auto &param = paramController.insert<int>("hint_only");
+  param.min(0.0).max(100.0);
+
+  handler.insert("hint_only", 999);
+  EXPECT_NO_THROW(paramController.check_parameter(handler));
+}
+
+TEST_F(InputParameterTest, TestMetadataReadableViaBaseRef) {
+  // Form-builders iterate the controller and read metadata via
+  // input_parameter_base — confirm the accessors work polymorphically.
+  using base_t = numsim_core::input_parameter_base<std::string, MockParameterHandler>;
+
+  input_parameter_controller<std::string, MockParameterHandler> paramController;
+  paramController.insert<std::size_t>("nx").min(1.0).max(1024.0).units("cells").description("grid x-resolution");
+
+  base_t const &base_ref = paramController.get("nx");
+  ASSERT_TRUE(base_ref.min().has_value());
+  EXPECT_DOUBLE_EQ(*base_ref.min(), 1.0);
+  ASSERT_TRUE(base_ref.max().has_value());
+  EXPECT_DOUBLE_EQ(*base_ref.max(), 1024.0);
+  EXPECT_EQ(base_ref.units(), "cells");
+  EXPECT_EQ(base_ref.description(), "grid x-resolution");
+}


### PR DESCRIPTION
Closes #5.

## Summary

Adds three chainable advisory-hint methods on \`input_parameter_base\` for downstream GUI form generators:

- \`.min(double)\` — soft lower bound
- \`.max(double)\` — soft upper bound
- \`.units(std::string)\` — free-form unit label

All three return the same input_parameter type so they compose with the existing \`.description()\` and \`.add<...>()\` chain. Read accessors (\`min()\`, \`max()\`, \`units()\`) mirror the setters; values are stored as \`std::optional\` so a missing hint is distinguishable from an explicit bound.

Existing parameters() schemas continue to work unchanged — the new methods are purely additive.

See #5 for the full design rationale.

## Stacked on #4

This PR is based on \`fix/cmake-header-only-cxx23\` (PR #4) because the schema additions otherwise inherit the C++20 default in \`origin/main\` and fail to compile against the existing \`std::print\` use in \`input_parameter_controller.h\`. When #4 merges, GitHub will auto-rebase this PR onto main and the diff will narrow to just the API additions.

## Test plan

- [x] \`cmake --build && ctest\` results unchanged from #4: same 2 pre-existing failures (\`InputParameterTest.TestInvalidType\`, \`input_parameter_controller_test\`); 44 of 46 pass. New tests for the chainable hints pass.
- [x] Downstream rvegen builds against this branch (tested with rvegen on \`feature/statistical-validation-tests\`, all 16 ctest pass).
- [ ] CI on this PR confirms the above.

## Out of scope

- Runtime enforcement of \`min\` / \`max\`. Currently advisory only; bound-checking-at-parse-time would be a separate \`add<...>\` policy and a behaviour change.
- The 2 pre-existing test failures (carried over from #4 / main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)