### PR TITLE
Mark any_printer's static map and free print() as inline (ODR fix)

### DIFF
--- a/include/numsim-core/any_printer.h
+++ b/include/numsim-core/any_printer.h
@@ -70,7 +70,7 @@ private:
   std::any const &m_data; ///< The `std::any` object being printed.
 };
 
-const std::unordered_map<
+inline const std::unordered_map<
     std::type_index, std::function<void(std::any const &, std::ostream &)>> any_print_wrapper::any_print_visitor{
                                      /**
                                       * @brief Visitor for printing `int` values from a `std::any` object.
@@ -231,7 +231,7 @@ const std::unordered_map<
 
 } // namespace numsim_core
 
-numsim_core::any_print_wrapper print(std::any const &data) {
+inline numsim_core::any_print_wrapper print(std::any const &data) {
   return numsim_core::any_print_wrapper(data);
 }
 


### PR DESCRIPTION
Closes #9.

## Summary

Adds \`inline\` to the two namespace-scope definitions in \`any_printer.h\` that the C++ inline rule needs to deduplicate across translation units. One-line change per definition, file-local — does not affect the public API.

See #9 for the full ODR write-up.

## Test plan

- [x] \`cmake --build && ctest\` passes (44 of 46 tests; the 2 pre-existing failures are unchanged from main and unrelated).
- [ ] CI on this PR confirms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)