### PR TITLE
Fix TestInvalidType: expect std::invalid_argument not std::bad_any_cast

### DIFF
--- a/tests/parameter_handler/main.cpp
+++ b/tests/parameter_handler/main.cpp
@@ -157,7 +157,10 @@ TEST_F(InputParameterTest, TestInvalidType) {
   param.add<check_data_type>();
 
   handler.insert("param_with_wrong_type", std::string("not_an_int"));
-  EXPECT_THROW(paramController.check_parameter(handler), std::bad_any_cast);
+  // The check catches std::bad_any_cast internally and rethrows as
+  // std::invalid_argument with a parameter-named diagnostic — strictly
+  // more useful than the bare bad_any_cast which carries no context.
+  EXPECT_THROW(paramController.check_parameter(handler), std::invalid_argument);
 }
 
 TEST_F(InputParameterTest, TestRequiredParameterMissing_Fail) {


### PR DESCRIPTION
Closes #11.

## Summary

Pre-existing test failure: \`InputParameterTest.TestInvalidType\` asserts \`bad_any_cast\` but the runtime correctly catches and rethrows as \`std::invalid_argument\` with a parameter-named diagnostic. The runtime behaviour is correct (more useful error message); the test was just never updated. One-line fix.

After this lands, ctest goes from 44/46 to 46/46 on a clean checkout, removing the noise that's been carried in every PR (#4, #7, #8, #10) since the dispatcher rework session.

## Test plan

- [x] \`ctest --test-dir build\` reports 46/46 passing locally on g++-14.
- [ ] CI on this PR confirms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)