### PR TITLE
Add description_label<"..."> policy for parameter descriptions

### DIFF
--- a/include/numsim-core/input_parameter_controller.h
+++ b/include/numsim-core/input_parameter_controller.h
@@ -168,6 +168,28 @@ public:
 };
 
 /**
+ * @brief Polymorphic side-base for any check that carries a free-form
+ * description string.
+ *
+ * Like \ref units_hint_base, the description is a compile-time string
+ * (NTTP fixed_string) so the accessor returns a string_view referencing
+ * static storage with zero runtime overhead. Used by GUI form generators
+ * for tooltips, by Doxygen-style doc generators, and by error
+ * formatters that want to print the human-readable name of a parameter.
+ */
+class description_hint_base {
+public:
+  description_hint_base() = default;
+  description_hint_base(description_hint_base const&) = delete;
+  description_hint_base(description_hint_base&&) = delete;
+  description_hint_base& operator=(description_hint_base const&) = delete;
+  description_hint_base& operator=(description_hint_base&&) = delete;
+  virtual ~description_hint_base() = default;
+
+  [[nodiscard]] virtual std::string_view description_text() const noexcept = 0;
+};
+
+/**
  * @brief Compile-time string wrapper usable as a non-type template
  * parameter (C++20 NTTP rules require a structural type — this is one).
  *
@@ -615,6 +637,57 @@ struct unit_label {
 
     [[nodiscard]] std::string_view units() const noexcept override {
       return Unit_.view();
+    }
+  };
+
+  template <typename T, typename KeyType, typename ParameterHandler>
+  [[nodiscard]] static auto instantiate(
+      input_parameter<T, KeyType, ParameterHandler> const& para)
+      -> std::unique_ptr<input_parameter_check_base<T, KeyType, ParameterHandler>> {
+    return std::make_unique<impl<T, KeyType, ParameterHandler>>(para);
+  }
+};
+
+// ===========================================================================
+// Description hint — pure metadata, no runtime check.
+//
+// Same shape as unit_label: NTTP fixed_string, side-base for
+// introspection, no-op runtime check, factory wrapper.
+//
+// Usage:
+//   s.template insert<std::size_t>("nx")
+//       .template add<numsim_core::is_required>()
+//       .template add<numsim_core::range<1u, 4096u>>()
+//       .template add<numsim_core::unit_label<"cells">>()
+//       .template add<numsim_core::description_label<
+//           "voxel-grid resolution along x">>();
+//
+// Consumed by GUI form-builders for tooltips and by error formatters
+// that want a human-readable name for the parameter.
+// ===========================================================================
+template <fixed_string Desc_>
+struct description_label {
+  template <typename T, typename KeyType, typename ParameterHandler>
+  class impl final
+      : public input_parameter_check_base<T, KeyType, ParameterHandler>,
+        public description_hint_base {
+  public:
+    using base = input_parameter_check_base<T, KeyType, ParameterHandler>;
+
+    impl() = delete;
+    impl(impl const&) = delete;
+    impl(impl&&) = delete;
+    impl& operator=(impl const&) = delete;
+    impl& operator=(impl&&) = delete;
+
+    explicit impl(
+        input_parameter<T, KeyType, ParameterHandler> const& para) noexcept
+        : base(para) {}
+
+    void check(ParameterHandler&) const final override {}  // no runtime check
+
+    [[nodiscard]] std::string_view description_text() const noexcept override {
+      return Desc_.view();
     }
   };
 

--- a/tests/parameter_handler/main.cpp
+++ b/tests/parameter_handler/main.cpp
@@ -351,3 +351,62 @@ TEST_F(InputParameterTest, TestRangePolicyWithDoubleBounds) {
   handler.insert("target_fraction", 1.5);
   EXPECT_THROW(paramController.check_parameter(handler), std::invalid_argument);
 }
+
+// ---------------------------------------------------------------------------
+// description_label policy
+// ---------------------------------------------------------------------------
+
+using numsim_core::description_hint_base;
+using numsim_core::description_label;
+
+TEST_F(InputParameterTest, TestDescriptionLabelExposesText) {
+  input_parameter_controller<std::string, MockParameterHandler> paramController;
+  auto &param = paramController.insert<int>("nx");
+  param.add<description_label<"voxel-grid resolution along x">>();
+
+  description_hint_base const* hint = nullptr;
+  for (auto const& check : param.checks()) {
+    if (auto const* h = dynamic_cast<description_hint_base const*>(check.get())) {
+      hint = h;
+      break;
+    }
+  }
+  ASSERT_NE(hint, nullptr);
+  EXPECT_EQ(hint->description_text(),
+            std::string_view{"voxel-grid resolution along x"});
+}
+
+TEST_F(InputParameterTest, TestDescriptionLabelHasNoRuntimeCheck) {
+  input_parameter_controller<std::string, MockParameterHandler> paramController;
+  auto &param = paramController.insert<int>("nx");
+  param.add<description_label<"a description">>();
+
+  EXPECT_NO_THROW(paramController.check_parameter(handler));   // missing
+  handler.insert("nx", -1);
+  EXPECT_NO_THROW(paramController.check_parameter(handler));   // present, any value
+}
+
+TEST_F(InputParameterTest, TestFullPolicyComposition) {
+  // The four canonical policies compose: validation (is_required +
+  // range) plus pure metadata (unit_label + description_label). Each
+  // side-base is independently introspectable from the GUI side.
+  input_parameter_controller<std::string, MockParameterHandler> paramController;
+  auto &param = paramController.insert<int>("nx");
+  param.add<is_required>();
+  param.add<range<1, 4096>>();
+  param.add<unit_label<"cells">>();
+  param.add<description_label<"voxel-grid resolution along x">>();
+
+  handler.insert("nx", 256);
+  EXPECT_NO_THROW(paramController.check_parameter(handler));
+
+  bool found_range = false, found_units = false, found_desc = false;
+  for (auto const& check : param.checks()) {
+    if (dynamic_cast<range_hint_base const*>(check.get())) found_range = true;
+    if (dynamic_cast<units_hint_base const*>(check.get())) found_units = true;
+    if (dynamic_cast<description_hint_base const*>(check.get())) found_desc = true;
+  }
+  EXPECT_TRUE(found_range);
+  EXPECT_TRUE(found_units);
+  EXPECT_TRUE(found_desc);
+}


### PR DESCRIPTION
Closes #13.

## Summary

Adds the third hint policy mirroring \`unit_label\`: \`description_label<fixed_string Desc_>\` carries a free-form human-readable description as a compile-time NTTP and exposes it via a new \`description_hint_base\` side-base for introspection.

Pattern is one-to-one identical to \`unit_label\` from PR #8: same \`fixed_string<N>\` NTTP wrapper, same factory \`instantiate()\`, same no-op runtime \`check()\`, same dual inheritance (the existing \`input_parameter_check_base\` for the policy slot, plus the new side-base for type-discriminated GUI access via \`dynamic_cast\`).

After this lands, the policy API is feature-complete for what rvegen currently uses via the old chained-method form (\`.description / .min / .units\`).

## Test plan

- [x] 3 new tests covering description-text introspection, no-op runtime, and the four-policy composition (\`is_required\` + \`range\` + \`unit_label\` + \`description_label\`). Test count goes 55 → 58, all passing.
- [ ] CI confirms.

## Out of scope

- The rvegen migration to use these policies — separate work in a separate repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)