### PR TITLE
Include missing parameter names in the validate-required exception text

### DIFF
--- a/include/numsim-core/input_parameter_controller.h
+++ b/include/numsim-core/input_parameter_controller.h
@@ -1163,13 +1163,23 @@ public:
         std::println("    using default: '{}'", key);
     }
 
-    // 4. Report all missing required parameters at once
+    // 4. Report all missing required parameters at once. The names are
+    //    included in the exception's what() so GUI consumers (which
+    //    only get the exception text — they don't capture stderr) can
+    //    show the user exactly which fields are missing rather than
+    //    just a count.
     if (!missing.empty()) {
       std::println("  missing required parameters:");
       for (const auto& key : missing)
         std::println("    - {}", key);
-      throw std::invalid_argument(
-          "missing " + std::to_string(missing.size()) + " required parameter(s)");
+      std::string msg =
+          "missing " + std::to_string(missing.size()) + " required parameter(s):";
+      for (const auto& key : missing) {
+        msg += " '";
+        msg += key;
+        msg += "'";
+      }
+      throw std::invalid_argument(msg);
     }
   }
 


### PR DESCRIPTION
## Why

GUI consumers of numsim-core (e.g. Tessera) display the `std::invalid_argument::what()` text directly to the user via a message box. Currently that text is just a count:

```
missing 1 required parameter(s)
```

which is unactionable — the user has to switch to a terminal and read the stderr trace to find out *which* parameter is missing. Screenshot of the unhelpful dialog: a Tessera 'Pipeline failed' popup saying 'missing 1 required parameter(s)' with no further detail.

## What

`input_parameter_controller::validate_required` now appends the missing key names to the exception text. The stderr `std::println` listing is kept (mostly for the CLI workflow) — only the exception what() gets the additional information.

Before: `missing 3 required parameter(s)`
After:  `missing 3 required parameter(s): 'a' 'b' 'c'`

## Compatibility

The old format is a strict prefix of the new format, so any string-matching consumer that grepped for the count still matches. Grep across numsim-core/tests, numsim-rvegen/, and numsim-tessera/ for `missing N required parameter(s)` finds zero call sites that depend on the exact suffix.

## Tests

- numsim-rvegen: 16/16 pass (rvegen drives the `validate_required` path via JSON config loading; nothing broke).
- numsim-tessera: 14/14 pass.
- Smoke: triggered the Pipeline-failed dialog in Tessera with a deliberately-incomplete config; the new message text now includes the missing key in the popup.