### PR TITLE
cmake: make the installed package consumable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,21 +27,6 @@ set(${PROJECT_NAME}_VERSION ${project_version})
 message(STATUS "Building v${${PROJECT_NAME}_VERSION}")
 
 # Header files
-set(${PROJECT_NAME}_HEADER
-    ${${PROJECT_NAME}_INCLUDE_DIR}/factory_base_bones.h
-    ${${PROJECT_NAME}_INCLUDE_DIR}/registry_bones.h
-    ${${PROJECT_NAME}_INCLUDE_DIR}/warehouse_bones.h
-    ${${PROJECT_NAME}_INCLUDE_DIR}/input_parameter_controller.h
-    ${${PROJECT_NAME}_INCLUDE_DIR}/input_parser.h
-    ${${PROJECT_NAME}_INCLUDE_DIR}/static_indexing.h
-    ${${PROJECT_NAME}_INCLUDE_DIR}/numsim_core_utility.h
-    ${${PROJECT_NAME}_INCLUDE_DIR}/query_map.h
-    ${${PROJECT_NAME}_INCLUDE_DIR}/parameter_handler.h
-    ${${PROJECT_NAME}_INCLUDE_DIR}/any_printer.h
-    ${${PROJECT_NAME}_INCLUDE_DIR}/wrapper.h
-    ${${PROJECT_NAME}_INCLUDE_DIR}/input_parameter_enum_utils.h
-    ${${PROJECT_NAME}_INCLUDE_DIR}/function_registry.h
-)
 
 # numsim-core is header-only: no sources, no compiled artefacts, just an
 # INTERFACE target carrying include paths + a C++23 feature requirement
@@ -100,7 +85,7 @@ if(${PROJECT_NAME}_INSTALL_LIBRARY)
     # one directory, so include/numsim-core/property_graph/*.h landed beside
     # the top-level headers and #include <numsim-core/property_graph/...>
     # could not resolve. It also only installed the files listed in
-    # ${PROJECT_NAME}_HEADER -- 13 of the 23 headers in the tree.
+    # a hand-maintained list -- 13 of the 23 headers in the tree.
     install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
             DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
             FILES_MATCHING PATTERN "*.h")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,14 @@ set(${PROJECT_NAME}_HEADER
 add_library(${PROJECT_NAME} INTERFACE)
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
+# GNUInstallDirs BEFORE the target_include_directories() below, not after it.
+# CMAKE_INSTALL_INCLUDEDIR is expanded when the line is read, so with the
+# include further down the INSTALL_INTERFACE expanded EMPTY and the exported
+# target carried no include directory at all -- consumers of the installed
+# package could find it and not compile against it. An empty INSTALL_INTERFACE
+# is legal, so nothing warned.
+include(GNUInstallDirs)
+
 # Headers are reachable from the build tree and from the install tree.
 target_include_directories(${PROJECT_NAME}
     INTERFACE
@@ -78,7 +86,6 @@ option(DOWNLOAD_GTEST "Download and build GTest" OFF)
 option(DOWNLOAD_GBENCHMARK "Download and build Google Benchmark" OFF)
 
 # Installation logic
-include(GNUInstallDirs)
 if(${PROJECT_NAME}_INSTALL_LIBRARY)
     install(
         TARGETS ${PROJECT_NAME}
@@ -89,8 +96,14 @@ if(${PROJECT_NAME}_INSTALL_LIBRARY)
     )
 
     # Install header files
-    install(FILES ${${PROJECT_NAME}_HEADER}
-            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})
+    # install(DIRECTORY), not install(FILES): FILES flattens everything into
+    # one directory, so include/numsim-core/property_graph/*.h landed beside
+    # the top-level headers and #include <numsim-core/property_graph/...>
+    # could not resolve. It also only installed the files listed in
+    # ${PROJECT_NAME}_HEADER -- 13 of the 23 headers in the tree.
+    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
+            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+            FILES_MATCHING PATTERN "*.h")
 
     # Create and install package config files
     include(CMakePackageConfigHelpers)


### PR DESCRIPTION
Fixes #18 — and a second defect found while verifying the first.

Both were invisible to every in-tree build, because those use `BUILD_INTERFACE`, which was always correct.

### 1. The exported target had no include directory

`include(GNUInstallDirs)` sat **18 lines after** the `$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>` that depends on it. `${}` expands when the line is read, so the variable was empty and the generator expression collapsed to `$<INSTALL_INTERFACE:>`:

```cmake
set_target_properties(numsim-core::numsim-core PROPERTIES
  INTERFACE_COMPILE_FEATURES "cxx_std_23"
)
```

Consumers could find the package and not compile against it. An empty `INSTALL_INTERFACE` is legal, so nothing warned. The `install(FILES ... DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/...)` call is *after* the include, which is why the headers landed correctly and only the export was wrong.

### 2. Headers installed flattened, and most were not installed at all

`install(FILES)` puts everything in one directory, so `include/numsim-core/property_graph/*.h` landed beside the top-level headers and `#include <numsim-core/property_graph/property_traits.h>` could not resolve. It also installed only the files listed in `${PROJECT_NAME}_HEADER` — **13 of the 23** headers in the tree.

```
before:  1 directory,  13 headers
after:   2 directories, 23 headers
```

`install(DIRECTORY ... FILES_MATCHING PATTERN "*.h")` installs all of them and preserves the structure. It also stops the list going stale: a new header no longer has to be added in two places.

### Verified end to end

A three-line external project that calls `find_package(numsim-core)` and includes a `property_graph` header now **configures, compiles and runs**. Before this it failed at configure on the missing include directory, and past that on the missing subdirectory.

Checked against the downstream case too: numsim-materials had its own separate packaging defect (its generated Config re-found none of its dependencies). With that fixed and these two, a consumer builds against an installed numsim-materials for the first time.

### Worth considering separately

Neither project's CI runs `install` or builds a consumer against the result, which is why all of this sat behind permanently green builds. A CI step that installs and compiles a three-line consumer would have caught every one of these.